### PR TITLE
Remove color annotations in RGB colored names relayed to Discord (fixes #9)

### DIFF
--- a/src/net/peacefulcraft/cowbot/CowBot.java
+++ b/src/net/peacefulcraft/cowbot/CowBot.java
@@ -46,12 +46,14 @@ public class CowBot extends Plugin {
 
   public void onEnable() {
     config = new Configuration();
-    if (config.getBotToken().length() > 0) {
+    if (config.getDatabaseName().length() > 0) {
       dbPool = new HikariManager(config);
       if (!dbPool.isAlive()) {
         logError("Unable to establish connections to MySQL server. Profile links will not work.");
       }
+    }
 
+    if (config.getBotToken().length() > 0) {
       cow = new Cow(config.getBotToken());
       botThread = new Thread(cow, "CowBot - Discord Bot");
       botThread.start();
@@ -109,6 +111,11 @@ public class CowBot extends Plugin {
     if (dbPool != null && dbPool.isAlive()) { dbPool.close(); }
 
     logMessage("CowBot Disabled");
+  }
+
+  // must strip message for "new" formatting characters which will slip through the legacy stripColor call. namely "&x"
+  public static String stripAmpersandBasedAndLegacyColorCodes(String message) {
+    return ChatColor.stripColor(message).replaceAll("&x", "");
   }
 
   public static void runAsync(Runnable task) {

--- a/src/net/peacefulcraft/cowbot/events/GameChatEvent.java
+++ b/src/net/peacefulcraft/cowbot/events/GameChatEvent.java
@@ -19,7 +19,6 @@ public class GameChatEvent implements Listener {
         String rank = RankTranslatior.serverRankToDiscordEmoji(
           LuckPermsProvider.get().getUserManager().getUser(event.getSender().getUniqueId()).getPrimaryGroup()
         );
-
         String message = rank + " **" + CowBot.stripAmpersandBasedAndLegacyColorCodes(event.getRawSenderNickname() + "**: " + event.getRawMessage());
         Snowflake gamechatChannelId = Snowflake.of(CowBot.getConfig().getGamechatChannelId());
         CowBot.getCow().getGatewayConnection().getChannelById(gamechatChannelId)

--- a/src/net/peacefulcraft/cowbot/events/GameChatEvent.java
+++ b/src/net/peacefulcraft/cowbot/events/GameChatEvent.java
@@ -3,7 +3,6 @@ package net.peacefulcraft.cowbot.events;
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.entity.channel.TextChannel;
 import net.luckperms.api.LuckPermsProvider;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 import net.peacefulcraft.cowbot.CowBot;
@@ -20,11 +19,12 @@ public class GameChatEvent implements Listener {
         String rank = RankTranslatior.serverRankToDiscordEmoji(
           LuckPermsProvider.get().getUserManager().getUser(event.getSender().getUniqueId()).getPrimaryGroup()
         );
-        String message = rank + " **" + ChatColor.stripColor(event.getRawSenderNickname() + "**: " + event.getRawMessage());
+
+        String message = rank + " **" + CowBot.stripAmpersandBasedAndLegacyColorCodes(event.getRawSenderNickname() + "**: " + event.getRawMessage());
         Snowflake gamechatChannelId = Snowflake.of(CowBot.getConfig().getGamechatChannelId());
         CowBot.getCow().getGatewayConnection().getChannelById(gamechatChannelId)
           .ofType(TextChannel.class)
-          .map(channel -> channel.createMessage(message))
+          .flatMap(channel -> channel.createMessage(message))
           .block();
       }
     );

--- a/src/net/peacefulcraft/cowbot/events/StaffChatEvent.java
+++ b/src/net/peacefulcraft/cowbot/events/StaffChatEvent.java
@@ -2,7 +2,6 @@ package net.peacefulcraft.cowbot.events;
 
 import discord4j.common.util.Snowflake;
 import discord4j.core.object.entity.channel.TextChannel;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 import net.peacefulcraft.cowbot.CowBot;
@@ -13,6 +12,7 @@ import xyz.olivermartin.multichat.bungee.events.PostStaffChatEvent;
 public class StaffChatEvent implements Listener {
   @EventHandler
   public void staffChatEvent(PostStaffChatEvent event) {
+    CowBot.logMessage("chat message type=" + event.getType());
     if (event.getType() == "mod") {
       if (CowBot.getConfig().getStaffchatChannelId() == null || CowBot.getConfig().getStaffchatChannelId().length() < 1) { return; }
       
@@ -23,7 +23,7 @@ public class StaffChatEvent implements Listener {
         () -> {
           event.getSender().getGroups().forEach((group) -> CowBot.logMessage(group));
           String rank = RankTranslatior.serverRankToDiscordEmoji(event.getSender().getGroups().iterator().next());
-          String message = rank + " **" + ChatColor.stripColor(event.getSenderName() + "**: " + event.getRawMessage());
+          String message = rank + " **" + CowBot.stripAmpersandBasedAndLegacyColorCodes(event.getSenderName() + "**: " + event.getRawMessage());
           Snowflake staffChannelId = Snowflake.of(CowBot.getConfig().getStaffchatChannelId());
           CowBot.getCow().getGatewayConnection().getChannelById(staffChannelId)
             .ofType(TextChannel.class)

--- a/src/net/peacefulcraft/cowbot/events/StaffChatEvent.java
+++ b/src/net/peacefulcraft/cowbot/events/StaffChatEvent.java
@@ -12,7 +12,6 @@ import xyz.olivermartin.multichat.bungee.events.PostStaffChatEvent;
 public class StaffChatEvent implements Listener {
   @EventHandler
   public void staffChatEvent(PostStaffChatEvent event) {
-    CowBot.logMessage("chat message type=" + event.getType());
     if (event.getType() == "mod") {
       if (CowBot.getConfig().getStaffchatChannelId() == null || CowBot.getConfig().getStaffchatChannelId().length() < 1) { return; }
       


### PR DESCRIPTION
This patch functionally only adds a String::replaceAll call, which I didn't think necessary to test on its own. Here are a subset of the manual end-to-end tests I devised and ran:

**Test 1 (single color):**
![1](https://user-images.githubusercontent.com/43277421/144722557-34bdb0f6-0769-401a-b30d-9678f491f85e.png)
Pre-patch: 
![2](https://user-images.githubusercontent.com/43277421/144722561-3e6c1409-7461-4547-9642-75d0a8990a9d.png)
![3](https://user-images.githubusercontent.com/43277421/144722564-7d60d1c1-736e-4cf4-b66d-2533c76b4ff2.png)
Post-patch:
![4](https://user-images.githubusercontent.com/43277421/144722569-db4d1da4-10f7-415b-ab22-b5c04c339916.png)
![5](https://user-images.githubusercontent.com/43277421/144722570-f9404f77-f72b-48c2-b643-ceb7dfafa24b.png)

**Test 2 (multicolored):**
![6](https://user-images.githubusercontent.com/43277421/144722576-303caf13-5190-4e74-8f14-15814b4cdd5e.png)
Pre-patch:
![7](https://user-images.githubusercontent.com/43277421/144722588-1230fbd6-6091-42b9-942c-938da97f25c7.png)
![8](https://user-images.githubusercontent.com/43277421/144722589-926d8d9a-ee79-4c7f-bb1f-b2d2fb503940.png)
Post-patch:
![9](https://user-images.githubusercontent.com/43277421/144722595-59c53f5f-74f4-44b8-ae56-9d8d79480515.png)
![10](https://user-images.githubusercontent.com/43277421/144722599-c923a4f1-6c67-46a6-9288-e599dfb0dd45.png)

**Test 3 (colored name with ‘x’s in it):**
![11](https://user-images.githubusercontent.com/43277421/144722602-8a29010b-4314-42df-a632-e1e472c4cccc.png)
Pre-patch:
![12](https://user-images.githubusercontent.com/43277421/144722607-1e443291-b87f-482c-ad4e-e2052150c6b2.png)
![13](https://user-images.githubusercontent.com/43277421/144722609-d7ba621c-c7d3-4f89-9937-0a139a3a97cf.png)
Post-patch:
![14](https://user-images.githubusercontent.com/43277421/144722615-fcc9ff4e-91f6-48c2-b9fd-c83726e8f77d.png)
![15](https://user-images.githubusercontent.com/43277421/144722617-41f03d66-8c5d-4160-952d-553cd4cdf8a0.png)

**Finally, a control test (no color):**
![16](https://user-images.githubusercontent.com/43277421/144722623-8077bdaa-b6c8-4ea6-af9b-70c86a2c3b05.png)
Pre-patch:
![17](https://user-images.githubusercontent.com/43277421/144722626-2c4207e2-efd4-48cb-8ee9-b1e132d65dc6.png)
![18](https://user-images.githubusercontent.com/43277421/144722632-39424c51-fe14-4929-816c-2f4484fbdc9e.png)
Post-patch:
![19](https://user-images.githubusercontent.com/43277421/144722635-620698a0-3366-4e77-9e49-699c90347a90.png)
![20](https://user-images.githubusercontent.com/43277421/144722637-5d7a602c-eded-4be8-bbee-5d3ab53f3b3f.png)


