### PR TITLE
add support for RGB colors from Discord, implements #8

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -37,5 +37,10 @@
 			<attribute name="m2e-apt" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target\generated-sources\annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
 
 	<dependencies>
 		<dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
 			<groupId>net.md-5</groupId>
 			<artifactId>bungeecord-api</artifactId>
 			<version>1.17-R0.1-SNAPSHOT</version>

--- a/src/net/peacefulcraft/cowbot/handlers/GameChatMessageHandler.java
+++ b/src/net/peacefulcraft/cowbot/handlers/GameChatMessageHandler.java
@@ -8,10 +8,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.peacefulcraft.cowbot.CowBot;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Stack;
+import net.peacefulcraft.cowbot.translation.DiscordToMinecraftFormattingTranslator;
 
 public class GameChatMessageHandler {
 
@@ -33,8 +30,9 @@ public class GameChatMessageHandler {
       .append(senderRank).color(ChatColor.of(rankColor))
       .append("]").color(ChatColor.GREEN)
       .append(author + ": ").color(ChatColor.GRAY);
-      // .append(content).color(ChatColor.WHITE);
-    formattedComponents = formatDiscordMessageForMinecraft(formattedComponents, content);
+
+    DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(content);
+    formattedComponents = translator.parse(formattedComponents);
 
     BaseComponent[] formattedMessage = formattedComponents.color(ChatColor.WHITE).create();
 
@@ -53,201 +51,5 @@ public class GameChatMessageHandler {
         player.sendMessage(formattedMessage);
       }
     }
-  }
-
-  /*
-   * A simple Discord formatting parser which converts to Minecraft formatting. 
-   * Doesn't look like there's a better way without using a library written in another language, or one which would do
-   * heavy-duty parsing of the entire Markdown language, which we don't want. For example, we want <b>test</b> to be passed
-   * along as plaintext. Formats character by character, which is easier to implement.
-   * 
-   * Only parses one layer deep -- will only check for the following:
-   * https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-
-   * 
-   * Keys:
-   * italics: * or _
-   * bold: **
-   * underline: __
-   * strikethrough: ~~
-   * obfuscated: ||
-   * escape key: \ (can escape itself)
-   */
-  private static class FormatToPos {
-    public FormatToPos(int f, int p) {
-      fmt = f;
-      pos = p;
-    }
-    int fmt;
-    int pos;
-  }
-  private static boolean shouldAddFormatting(int fmt, int i, List<Stack<FormatToPos>> formats) {
-    // only add if greater than or equal to start of range
-    boolean should = !formats.get(fmt).empty() && i >= formats.get(fmt).peek().fmt;
-    if (should) {
-      CowBot.logMessage("APPLYING " + fmt + " TO INDEX " + i);
-    }
-    return should;
-  }
-  private static ComponentBuilder formatDiscordMessageForMinecraft(ComponentBuilder formattedPrefix, String content) {
-    CowBot.logMessage("BEGINNING PARSING");
-    int ITALICS_UND = 0;
-    int ITALICS_AST = 1;
-    int BOLD = 2;
-    int UNDERLINE = 3;
-    int STRIKETHROUGH = 4;
-    int OBFUSCATED = 5;
-    String[] types = {"ITALICS_UND", "ITALICS_AST", "BOLD", "UNDERLINE", "STRIKETHROUGH", "OBFUSCATED" };
-
-    // -1 means closed, otherwise the value is the pos at which this was opened
-    int NOT_OPEN = content.length()+1; // so open values always compare as "more recent"
-    int[] isOpen = {NOT_OPEN, NOT_OPEN, NOT_OPEN, NOT_OPEN, NOT_OPEN, NOT_OPEN};
-
-    // whether or not this character should be ignored in the output (formatting char)
-    boolean[] ignore = new boolean[content.length()];
-
-    // stack of observed formatting characters
-    Stack<FormatToPos> stack = new Stack<FormatToPos>();
-
-    List<Stack<FormatToPos>> formats = new ArrayList<Stack<FormatToPos>>(6);
-    for (int i = 0; i < 6; ++i) {
-      formats.add(new Stack<FormatToPos>());
-    }
-    // compile time hash table which stores which formatting codes are currently "open" (basically vector of bool isOpen)
-    // stack which stores which formatting codes are open, but in order of which we expect to close first
-    // basic alg: 
-    // if see formatting code:
-    //    if not already open (check hash table): open it and add it to stack (with position in string)
-    //    else: close it, popping off anything which was in its way on the stack (returning those to their previous positions in the string)
-    //      then, remember that string of formatting (push into relevant queue)
-    // else: do nothing
-
-    // result is 5 queues (one for each formatting type) with start, end pairs.
-    // then go through each char, check which types of formatting it should have, and append it to the formatted message
-    for (int i = content.length()-1; i >= 0; --i) {
-      char curr = content.charAt(i);
-      char prev = i == 0 ? ' ' : content.charAt(i-1); // todo mj account for corner cases with mulitple *s, multiple _s
-      int format = -1;
-      if (prev == '\\' && (curr == '*' || curr == '_' || curr == '~' || curr == '|')) {
-        // ignore escape char and continue
-        ignore[i-1] = true;
-        continue;
-      }
-
-      if (curr == '*') {
-        format = ITALICS_AST;
-
-        // prefer whichever formatting code is closer to the top of the stack
-        // but break ties in favor of the 'stronger' formatting (bold, here)
-        if (prev == '*' && isOpen[ITALICS_AST] >= isOpen[BOLD]) {
-          format = BOLD;
-        }
-      } else if (curr == '_') {
-        format = ITALICS_UND;
-
-        // same as above, prefer whichever is closer to top of stack
-        if (prev == '_' && isOpen[ITALICS_UND] >= isOpen[UNDERLINE]) {
-          format = UNDERLINE;
-        }
-      } else if (curr == '~' && prev == '~') {
-        format = STRIKETHROUGH;
-      } else if (curr == '|' && prev == '|') {
-        format = OBFUSCATED;
-      } else {
-        // nothing, continue
-        continue;
-      }
-
-      CowBot.logMessage(types[format] + " DETECTED");
-
-      // set the formatting chars to be ignored in the string
-      ignore[i] = true;
-      if (format != ITALICS_AST && format != ITALICS_UND) { // todo mj make hash table of format configs so this is extensible? can just check "is_double"
-        // two character codes get double ignores
-        ignore[i-1] = true;
-        // decrement index twice to prevent double counting the formatting
-        --i;
-      }
-
-      // determine if this is an opening reference or a closing one
-      if (isOpen[format] != NOT_OPEN) {
-        // close the reference, popping any which are on "top" of it in the process
-        while (stack.peek().fmt != format) {
-          isOpen[stack.peek().fmt] = NOT_OPEN;
-
-          // un-ignore the keys
-          ignore[stack.peek().pos] = false;
-          if (stack.peek().fmt != ITALICS_AST && stack.peek().fmt != ITALICS_UND) {
-            ignore[stack.peek().pos+1] = false;
-          }
-          stack.pop();
-        }
-        
-        // ref is now closed! note that we have an open, close pair
-        isOpen[format] = NOT_OPEN;
-        // i is openpos, remembered pos is closepos
-        formats.get(format).push(new FormatToPos(i, stack.peek().pos));
-        stack.pop();
-      } else {
-        // opening reference, save it
-        isOpen[format] = i;
-        stack.push(new FormatToPos(format, i));
-      }
-    }
-    CowBot.logMessage("DONE WITH PARSING");
-    
-    // whatever is open still never got closed, must pop off and un-ignore
-    while(!stack.empty()) {
-      ignore[stack.peek().pos] = false;
-      if (stack.peek().fmt != ITALICS_AST && stack.peek().fmt != ITALICS_UND) {
-        ignore[stack.peek().pos+1] = false;
-      }
-      stack.pop();
-    }
-
-    // iterate over pairs in formats, set chars accordingly
-    CowBot.logMessage("MESSAGE PARSING DEBUG LOG");
-    CowBot.logMessage("content: " + content);
-    String ignoreStr = "";
-    for (int i = 0; i < content.length(); ++i) {
-      ignoreStr += (ignore[i] ? "T" : "F");
-    }
-    CowBot.logMessage("ignores: " + ignoreStr);
-    String fmtString = "";
-    for (int i = 0; i < 6; i++) {
-      if (formats.get(i).empty()) {
-        continue;
-      }
-      CowBot.logMessage(types[i] + " FOUND:");
-      for (int j = 0; j < formats.get(i).size(); ++j) {
-        CowBot.logMessage("\t(" + formats.get(i).get(j).fmt + "," + formats.get(i).get(j).pos + ")");
-      }
-    }
-    CowBot.logMessage("FORMATTING: " + fmtString);
-
-    // now iterate through the chars and add them with their proper formatting to the builder
-    for (int i = 0; i < content.length(); ++i) {
-      // first pop all used-up formatters
-      for (int f = 0; f < formats.size(); ++f) {
-        while (!formats.get(f).empty() && formats.get(f).peek().pos <= i) {
-          formats.get(f).pop();
-        }
-      }
-
-      // ignore if not adding
-      if (ignore[i]) {
-        continue;
-      }
-
-      // add char with all formatting, then reset
-      formattedPrefix.append("").reset();
-      formattedPrefix.append("" + content.charAt(i));
-      formattedPrefix.italic(shouldAddFormatting(ITALICS_AST, i, formats) || shouldAddFormatting(ITALICS_UND, i, formats));
-      formattedPrefix.bold(shouldAddFormatting(BOLD, i, formats));
-      formattedPrefix.underlined(shouldAddFormatting(UNDERLINE, i, formats));
-      formattedPrefix.strikethrough(shouldAddFormatting(STRIKETHROUGH, i, formats));
-      formattedPrefix.obfuscated(shouldAddFormatting(OBFUSCATED, i, formats));
-    }
-
-    return formattedPrefix;
   }
 }

--- a/src/net/peacefulcraft/cowbot/handlers/GameChatMessageHandler.java
+++ b/src/net/peacefulcraft/cowbot/handlers/GameChatMessageHandler.java
@@ -15,7 +15,9 @@ public class GameChatMessageHandler {
     String author = message.getAuthor().get().getUsername();
     Member sender = message.getAuthor().get().asMember(message.getGuild().block().getId()).block();
     Color color = sender.getColor().block();
-    String roleHex = String.format("#%02X%02X%02X", color.getRed(), color.getBlue(), color.getGreen());
+
+    // fully qualified name to avoid name collisions with discord4j Color
+    java.awt.Color rankColor = new java.awt.Color(color.getRed(), color.getGreen(), color.getBlue());
     
     String senderRank = sender.getHighestRole().block().getName();
     String content = message.getContent();
@@ -24,7 +26,7 @@ public class GameChatMessageHandler {
       .append("[").color(ChatColor.GREEN)
       .append("Discord").color(ChatColor.GOLD)
       .append("][").color(ChatColor.GREEN)
-      .append(senderRank).color(ChatColor.of(roleHex))
+      .append(senderRank).color(ChatColor.of(rankColor))
       .append("]").color(ChatColor.GREEN)
       .append(author + ": ").color(ChatColor.GRAY)
       .append(content).color(ChatColor.WHITE).create();
@@ -33,7 +35,7 @@ public class GameChatMessageHandler {
         ChatColor.GREEN + " [" +
         ChatColor.GOLD + "Discord" +
         ChatColor.GREEN + "][" +
-        ChatColor.of(roleHex) + senderRank +
+        ChatColor.of(rankColor) + senderRank +
         ChatColor.GREEN + "]" + 
         ChatColor.GRAY + author + ": " + 
         ChatColor.WHITE + content

--- a/src/net/peacefulcraft/cowbot/handlers/GameChatMessageHandler.java
+++ b/src/net/peacefulcraft/cowbot/handlers/GameChatMessageHandler.java
@@ -32,7 +32,7 @@ public class GameChatMessageHandler {
       .append(author + ": ").color(ChatColor.GRAY);
 
     DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(content);
-    formattedComponents = translator.parse(formattedComponents);
+    formattedComponents = translator.translate(formattedComponents);
 
     BaseComponent[] formattedMessage = formattedComponents.color(ChatColor.WHITE).create();
 

--- a/src/net/peacefulcraft/cowbot/handlers/GameChatMessageHandler.java
+++ b/src/net/peacefulcraft/cowbot/handlers/GameChatMessageHandler.java
@@ -9,6 +9,10 @@ import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.peacefulcraft.cowbot.CowBot;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+
 public class GameChatMessageHandler {
 
   public static void handle(Message message) {
@@ -22,14 +26,17 @@ public class GameChatMessageHandler {
     String senderRank = sender.getHighestRole().block().getName();
     String content = message.getContent();
 
-    BaseComponent[] formattedMessage = new ComponentBuilder()
+    ComponentBuilder formattedComponents = new ComponentBuilder()
       .append("[").color(ChatColor.GREEN)
       .append("Discord").color(ChatColor.GOLD)
       .append("][").color(ChatColor.GREEN)
       .append(senderRank).color(ChatColor.of(rankColor))
       .append("]").color(ChatColor.GREEN)
-      .append(author + ": ").color(ChatColor.GRAY)
-      .append(content).color(ChatColor.WHITE).create();
+      .append(author + ": ").color(ChatColor.GRAY);
+      // .append(content).color(ChatColor.WHITE);
+    formattedComponents = formatDiscordMessageForMinecraft(formattedComponents, content);
+
+    BaseComponent[] formattedMessage = formattedComponents.color(ChatColor.WHITE).create();
 
       CowBot.logMessage(
         ChatColor.GREEN + " [" +
@@ -46,5 +53,201 @@ public class GameChatMessageHandler {
         player.sendMessage(formattedMessage);
       }
     }
+  }
+
+  /*
+   * A simple Discord formatting parser which converts to Minecraft formatting. 
+   * Doesn't look like there's a better way without using a library written in another language, or one which would do
+   * heavy-duty parsing of the entire Markdown language, which we don't want. For example, we want <b>test</b> to be passed
+   * along as plaintext. Formats character by character, which is easier to implement.
+   * 
+   * Only parses one layer deep -- will only check for the following:
+   * https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-
+   * 
+   * Keys:
+   * italics: * or _
+   * bold: **
+   * underline: __
+   * strikethrough: ~~
+   * obfuscated: ||
+   * escape key: \ (can escape itself)
+   */
+  private static class FormatToPos {
+    public FormatToPos(int f, int p) {
+      fmt = f;
+      pos = p;
+    }
+    int fmt;
+    int pos;
+  }
+  private static boolean shouldAddFormatting(int fmt, int i, List<Stack<FormatToPos>> formats) {
+    // only add if greater than or equal to start of range
+    boolean should = !formats.get(fmt).empty() && i >= formats.get(fmt).peek().fmt;
+    if (should) {
+      CowBot.logMessage("APPLYING " + fmt + " TO INDEX " + i);
+    }
+    return should;
+  }
+  private static ComponentBuilder formatDiscordMessageForMinecraft(ComponentBuilder formattedPrefix, String content) {
+    CowBot.logMessage("BEGINNING PARSING");
+    int ITALICS_UND = 0;
+    int ITALICS_AST = 1;
+    int BOLD = 2;
+    int UNDERLINE = 3;
+    int STRIKETHROUGH = 4;
+    int OBFUSCATED = 5;
+    String[] types = {"ITALICS_UND", "ITALICS_AST", "BOLD", "UNDERLINE", "STRIKETHROUGH", "OBFUSCATED" };
+
+    // -1 means closed, otherwise the value is the pos at which this was opened
+    int NOT_OPEN = content.length()+1; // so open values always compare as "more recent"
+    int[] isOpen = {NOT_OPEN, NOT_OPEN, NOT_OPEN, NOT_OPEN, NOT_OPEN, NOT_OPEN};
+
+    // whether or not this character should be ignored in the output (formatting char)
+    boolean[] ignore = new boolean[content.length()];
+
+    // stack of observed formatting characters
+    Stack<FormatToPos> stack = new Stack<FormatToPos>();
+
+    List<Stack<FormatToPos>> formats = new ArrayList<Stack<FormatToPos>>(6);
+    for (int i = 0; i < 6; ++i) {
+      formats.add(new Stack<FormatToPos>());
+    }
+    // compile time hash table which stores which formatting codes are currently "open" (basically vector of bool isOpen)
+    // stack which stores which formatting codes are open, but in order of which we expect to close first
+    // basic alg: 
+    // if see formatting code:
+    //    if not already open (check hash table): open it and add it to stack (with position in string)
+    //    else: close it, popping off anything which was in its way on the stack (returning those to their previous positions in the string)
+    //      then, remember that string of formatting (push into relevant queue)
+    // else: do nothing
+
+    // result is 5 queues (one for each formatting type) with start, end pairs.
+    // then go through each char, check which types of formatting it should have, and append it to the formatted message
+    for (int i = content.length()-1; i >= 0; --i) {
+      char curr = content.charAt(i);
+      char prev = i == 0 ? ' ' : content.charAt(i-1); // todo mj account for corner cases with mulitple *s, multiple _s
+      int format = -1;
+      if (prev == '\\' && (curr == '*' || curr == '_' || curr == '~' || curr == '|')) {
+        // ignore escape char and continue
+        ignore[i-1] = true;
+        continue;
+      }
+
+      if (curr == '*') {
+        format = ITALICS_AST;
+
+        // prefer whichever formatting code is closer to the top of the stack
+        // but break ties in favor of the 'stronger' formatting (bold, here)
+        if (prev == '*' && isOpen[ITALICS_AST] >= isOpen[BOLD]) {
+          format = BOLD;
+        }
+      } else if (curr == '_') {
+        format = ITALICS_UND;
+
+        // same as above, prefer whichever is closer to top of stack
+        if (prev == '_' && isOpen[ITALICS_UND] >= isOpen[UNDERLINE]) {
+          format = UNDERLINE;
+        }
+      } else if (curr == '~' && prev == '~') {
+        format = STRIKETHROUGH;
+      } else if (curr == '|' && prev == '|') {
+        format = OBFUSCATED;
+      } else {
+        // nothing, continue
+        continue;
+      }
+
+      CowBot.logMessage(types[format] + " DETECTED");
+
+      // set the formatting chars to be ignored in the string
+      ignore[i] = true;
+      if (format != ITALICS_AST && format != ITALICS_UND) { // todo mj make hash table of format configs so this is extensible? can just check "is_double"
+        // two character codes get double ignores
+        ignore[i-1] = true;
+        // decrement index twice to prevent double counting the formatting
+        --i;
+      }
+
+      // determine if this is an opening reference or a closing one
+      if (isOpen[format] != NOT_OPEN) {
+        // close the reference, popping any which are on "top" of it in the process
+        while (stack.peek().fmt != format) {
+          isOpen[stack.peek().fmt] = NOT_OPEN;
+
+          // un-ignore the keys
+          ignore[stack.peek().pos] = false;
+          if (stack.peek().fmt != ITALICS_AST && stack.peek().fmt != ITALICS_UND) {
+            ignore[stack.peek().pos+1] = false;
+          }
+          stack.pop();
+        }
+        
+        // ref is now closed! note that we have an open, close pair
+        isOpen[format] = NOT_OPEN;
+        // i is openpos, remembered pos is closepos
+        formats.get(format).push(new FormatToPos(i, stack.peek().pos));
+        stack.pop();
+      } else {
+        // opening reference, save it
+        isOpen[format] = i;
+        stack.push(new FormatToPos(format, i));
+      }
+    }
+    CowBot.logMessage("DONE WITH PARSING");
+    
+    // whatever is open still never got closed, must pop off and un-ignore
+    while(!stack.empty()) {
+      ignore[stack.peek().pos] = false;
+      if (stack.peek().fmt != ITALICS_AST && stack.peek().fmt != ITALICS_UND) {
+        ignore[stack.peek().pos+1] = false;
+      }
+      stack.pop();
+    }
+
+    // iterate over pairs in formats, set chars accordingly
+    CowBot.logMessage("MESSAGE PARSING DEBUG LOG");
+    CowBot.logMessage("content: " + content);
+    String ignoreStr = "";
+    for (int i = 0; i < content.length(); ++i) {
+      ignoreStr += (ignore[i] ? "T" : "F");
+    }
+    CowBot.logMessage("ignores: " + ignoreStr);
+    String fmtString = "";
+    for (int i = 0; i < 6; i++) {
+      if (formats.get(i).empty()) {
+        continue;
+      }
+      CowBot.logMessage(types[i] + " FOUND:");
+      for (int j = 0; j < formats.get(i).size(); ++j) {
+        CowBot.logMessage("\t(" + formats.get(i).get(j).fmt + "," + formats.get(i).get(j).pos + ")");
+      }
+    }
+    CowBot.logMessage("FORMATTING: " + fmtString);
+
+    // now iterate through the chars and add them with their proper formatting to the builder
+    for (int i = 0; i < content.length(); ++i) {
+      // first pop all used-up formatters
+      for (int f = 0; f < formats.size(); ++f) {
+        while (!formats.get(f).empty() && formats.get(f).peek().pos <= i) {
+          formats.get(f).pop();
+        }
+      }
+
+      // ignore if not adding
+      if (ignore[i]) {
+        continue;
+      }
+
+      // add char with all formatting, then reset
+      formattedPrefix.append("").reset();
+      formattedPrefix.append("" + content.charAt(i));
+      formattedPrefix.italic(shouldAddFormatting(ITALICS_AST, i, formats) || shouldAddFormatting(ITALICS_UND, i, formats));
+      formattedPrefix.bold(shouldAddFormatting(BOLD, i, formats));
+      formattedPrefix.underlined(shouldAddFormatting(UNDERLINE, i, formats));
+      formattedPrefix.strikethrough(shouldAddFormatting(STRIKETHROUGH, i, formats));
+      formattedPrefix.obfuscated(shouldAddFormatting(OBFUSCATED, i, formats));
+    }
+
+    return formattedPrefix;
   }
 }

--- a/src/net/peacefulcraft/cowbot/handlers/ModChatMessageHandler.java
+++ b/src/net/peacefulcraft/cowbot/handlers/ModChatMessageHandler.java
@@ -13,7 +13,7 @@ public class ModChatMessageHandler {
 
   public static void handle(Message message) {
     if (!message.getAuthor().isPresent()) { return; }
-    String author = message.getAuthor().get().getUsername();;
+    String author = message.getAuthor().get().getUsername();
     String content = message.getContent();
     lastUsernameRelayed = author;
     lastMessageRelayed = content;

--- a/src/net/peacefulcraft/cowbot/translation/DiscordToMinecraftFormattingTranslator.java
+++ b/src/net/peacefulcraft/cowbot/translation/DiscordToMinecraftFormattingTranslator.java
@@ -1,0 +1,265 @@
+package net.peacefulcraft.cowbot.translation;
+
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.peacefulcraft.cowbot.CowBot;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+
+/*
+* A simple Discord formatting parser which converts to Minecraft formatting.
+* 
+* Will only check for the following:
+* https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-
+* 
+* Keys:
+* italics: * or _
+* bold: **
+* underline: __
+* strikethrough: ~~
+* obfuscated: ||
+* escape key: \ (can escape itself)
+* 
+*/
+public class DiscordToMinecraftFormattingTranslator {
+
+  /* STATIC CONSTANTS */
+  private static int NUM_FORMATS = 6;
+
+  private static int ITALICS_UND = 0;
+  private static int ITALICS_AST = 1;
+  private static int BOLD = 2;
+  private static int UNDERLINE = 3;
+  private static int STRIKETHROUGH = 4;
+  private static int OBFUSCATED = 5;
+  private static String[] types = {"ITALICS_UND", "ITALICS_AST", "BOLD", "UNDERLINE", "STRIKETHROUGH", "OBFUSCATED" };
+  
+  private static int ESCAPE_CHAR = -1;
+
+  /* DATA MEMBERS */
+  private String content;
+  private int NOT_OPEN;
+  private int[] isOpen = new int[NUM_FORMATS];
+  private List<Stack<Range>> formats = new ArrayList<Stack<Range>>(NUM_FORMATS);
+  private boolean[] ignore;
+
+  /* PUBLIC MEMBER FUNCTIONS */
+  public DiscordToMinecraftFormattingTranslator(String content_) {
+      content = content_;
+
+      // sentinel "not open" value set higher, so open values always compare as "more recent"
+      NOT_OPEN = content.length()+1;
+      ignore = new boolean[content.length()];
+      for (int i = 0; i < NUM_FORMATS; ++i) {
+          isOpen[i] = NOT_OPEN;
+          formats.add(new Stack<Range>());
+      }
+  }
+
+  public ComponentBuilder parse() {
+    ComponentBuilder cb = new ComponentBuilder();
+    return parse(cb);
+  }
+
+  public ComponentBuilder parse(ComponentBuilder formattedPrefix) {
+
+    // stack of observed formatting characters
+    Stack<OpenFormat> stack = new Stack<OpenFormat>();
+  
+    // todo mj try iterating in forward order
+  
+    for (int i = content.length()-1; i >= 0; --i) {
+    // for (int i = 0; i < content.length(); ++i) {
+      char curr = content.charAt(i);
+      char prev = i == 0 ? ' ' : content.charAt(i-1);
+      char prevprev = i > 1 ? content.charAt(i-2) : ' ';
+      int format = -1;
+
+    //   // handle escape char first
+    //   if (prev == '\\' && (curr == '*' || curr == '_' || curr == '~' || curr == '|' || curr == '\\')) {
+    //     ignore[i-1] = true;
+    //     --i;
+    //     continue;
+    //   }
+    //   // also applies to all 'double char' formatting codes
+    //   if (prevprev == '\\' && ((curr == '~' && prev == '~') || (curr == '_' && prev == '_') || (curr == '|' && prev == '|') || (curr == '*' && prev == '*'))) {
+    //     ignore[i-2] = true;
+    //     i-=2;
+    //     continue;
+    //   }
+
+      if (curr == '*') {
+        format = ITALICS_AST;
+
+        // prefer whichever formatting code is closer to the top of the stack
+        // but break ties in favor of the 'stronger' formatting (bold, here)
+        if (prev == '*' && isOpen[ITALICS_AST] >= isOpen[BOLD]) {
+          format = BOLD;
+        }
+      } else if (curr == '_') {
+        format = ITALICS_UND;
+
+        // same as above, break ties in favor of underline
+        if (prev == '_' && isOpen[ITALICS_UND] >= isOpen[UNDERLINE]) {
+          format = UNDERLINE;
+        }
+      } else if (curr == '~' && prev == '~') {
+        format = STRIKETHROUGH;
+      } else if (curr == '|' && prev == '|') {
+        format = OBFUSCATED;
+      } else if (curr == '\\') {
+        format = ESCAPE_CHAR; 
+      } else {
+        // nothing, continue
+        continue;
+      }
+
+      // if the code is escaped, continue, ignoring the escape char
+      if (isEscaped(format, curr, prev, prevprev)) {
+        CowBot.logMessage("ESCAPED CHAR: " + (format != ESCAPE_CHAR ? types[format] : "ESCAPE_CHAR"));
+        if (isSingleCharFormatType(format)) {
+            i--;
+        } else {
+            i-=2;
+        }
+        ignore[i] = true;
+        continue;
+      }
+
+      // if there's an un-escaped escape char (just a backslash), treat that as a normal character
+      if (format == ESCAPE_CHAR) {
+        continue;
+      }
+
+      // set the formatting chars to be ignored in the string
+      ignore[i] = true;
+      if (!isSingleCharFormatType(format)) {
+        // two character codes get double ignores
+        ignore[i-1] = true;
+        // decrement index twice to prevent double counting the formatting
+        --i;
+      }
+
+      // determine if this is an opening reference or a closing one
+      if (isOpen[format] != NOT_OPEN) {
+        // close the reference, popping any which are on "top" of it in the process
+        while (stack.peek().format != format) {
+          isOpen[stack.peek().format] = NOT_OPEN;
+
+          // un-ignore the keys
+          ignore[stack.peek().openedAtPos] = false;
+          if (!isSingleCharFormatType(stack.peek().format)) {
+            ignore[stack.peek().openedAtPos+1] = false;
+          }
+          stack.pop();
+        }
+
+        // ref is now closed! note that we have an open, close pair
+        formats.get(format).push(new Range(i, stack.peek().openedAtPos));
+        isOpen[format] = NOT_OPEN;
+        stack.pop();
+
+      } else {
+        // opening reference, save it
+        isOpen[format] = i;
+        stack.push(new OpenFormat(format, i));
+      }
+    }
+
+    // whatever is open still never got closed, must pop off and un-ignore
+    while(!stack.empty()) {
+      ignore[stack.peek().openedAtPos] = false;
+      if (!isSingleCharFormatType(stack.peek().format)) {
+        ignore[stack.peek().openedAtPos+1] = false;
+      }
+      stack.pop();
+    }
+    
+    // for debugging purposes
+    logParsingData(ignore, formats);
+
+    // now iterate through the chars and add them with their proper formatting to the builder
+    for (int i = 0; i < content.length(); ++i) {
+      // first pop all used-up formatters
+      for (int f = 0; f < formats.size(); ++f) {
+        while (!formats.get(f).empty() && formats.get(f).peek().end <= i) {
+          formats.get(f).pop();
+        }
+      }
+
+      // ignore if not adding
+      if (ignore[i]) {
+        continue;
+      }
+
+      // reset formatting then add current char with all types
+      formattedPrefix.append("").reset();
+      formattedPrefix.append("" + content.charAt(i));
+      formattedPrefix.italic(shouldAddFormatting(ITALICS_AST, i, formats) || shouldAddFormatting(ITALICS_UND, i, formats));
+      formattedPrefix.bold(shouldAddFormatting(BOLD, i, formats));
+      formattedPrefix.underlined(shouldAddFormatting(UNDERLINE, i, formats));
+      formattedPrefix.strikethrough(shouldAddFormatting(STRIKETHROUGH, i, formats));
+      formattedPrefix.obfuscated(shouldAddFormatting(OBFUSCATED, i, formats));
+    }
+
+    return formattedPrefix;
+  }
+
+  /* PRIVATE HELPERS */
+  private class OpenFormat {
+    public OpenFormat(int f, int p) {
+      format = f;
+      openedAtPos = p;
+    }
+    int format;
+    int openedAtPos;
+  }
+
+  private class Range {
+      public Range(int s, int e) {
+          start = s;
+          end = e;
+      }
+      int start;
+      int end;
+  }
+
+  private boolean isEscaped(int format, char curr, char prev, char prevprev) {
+    // if single char format type, just check prev, else check prevprev
+    if (isSingleCharFormatType(format)) {
+        return prev == '\\';
+    }
+    return prevprev == '\\';
+  }
+
+  private boolean isSingleCharFormatType(int format) {
+    return format == ITALICS_AST || format == ITALICS_UND || format == ESCAPE_CHAR;
+  }
+
+  private boolean shouldAddFormatting(int fmt, int i, List<Stack<Range>> formats) {
+    // only add if greater than or equal to start of range
+    return !formats.get(fmt).empty() && i >= formats.get(fmt).peek().start;
+  }
+
+  private void logParsingData(boolean[] ignore, List<Stack<Range>> formats) {
+    CowBot.logMessage("MESSAGE PARSING DEBUG LOG");
+    CowBot.logMessage("content: " + content);
+    String ignoreStr = "";
+    for (int i = 0; i < content.length(); ++i) {
+      ignoreStr += (ignore[i] ? "T" : "F");
+    }
+    CowBot.logMessage("ignores: " + ignoreStr);
+    String fmtString = "";
+    for (int i = 0; i < NUM_FORMATS; i++) {
+      if (formats.get(i).empty()) {
+        continue;
+      }
+      CowBot.logMessage(types[i] + " FOUND:");
+      for (int j = 0; j < formats.get(i).size(); ++j) {
+        CowBot.logMessage("\t(" + formats.get(i).get(j).start + "," + formats.get(i).get(j).end + ")");
+      }
+    }
+    CowBot.logMessage("FORMATTING: " + fmtString);
+  }
+}

--- a/src/net/peacefulcraft/cowbot/translation/DiscordToMinecraftFormattingTranslator.java
+++ b/src/net/peacefulcraft/cowbot/translation/DiscordToMinecraftFormattingTranslator.java
@@ -1,11 +1,8 @@
 package net.peacefulcraft.cowbot.translation;
 
-import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.peacefulcraft.cowbot.CowBot;
-
-import java.util.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +11,7 @@ import java.util.Stack;
 /*
 * A simple Discord formatting parser which converts to Minecraft formatting.
 * Class is split up to allow better unit testing.
+* Does not match true Discord formatting for complex patterns.
 * 
 * Supports the following formatting features:
 * https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-
@@ -71,7 +69,7 @@ public class DiscordToMinecraftFormattingTranslator {
           formats.add(new Stack<Range>());
       }
       parse();
-      logParsingData();
+      // logParsingData();
   }
 
   // used by unit tests
@@ -162,8 +160,6 @@ public class DiscordToMinecraftFormattingTranslator {
   private void parse() {
     // stack of observed formatting characters
     Stack<OpenFormat> stack = new Stack<OpenFormat>();
-  
-    // todo mj need to iterate in forward order to have same behavior as discord?
   
     for (int i = content.length()-1; i >= 0; --i) {
       char curr = content.charAt(i);

--- a/src/test/java/TestDiscordToMinecraftFormattingTranslator.java
+++ b/src/test/java/TestDiscordToMinecraftFormattingTranslator.java
@@ -1,0 +1,205 @@
+package test.java;
+
+import net.peacefulcraft.cowbot.translation.DiscordToMinecraftFormattingTranslator;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Stack;
+
+public class TestDiscordToMinecraftFormattingTranslator {
+
+    @Test
+    public void testSimpleItalicsAst() {
+        String message = "*i*";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> result = translator.getItalicsAst();
+        assertEquals(0, result.peek().start);
+        assertEquals(2, result.peek().end);
+        result.pop();
+        assertTrue(result.empty());
+        assertTrue(translator.getItalicsUnd().empty());
+        assertTrue(translator.getBold().empty());
+        assertTrue(translator.getUnderlines().empty());
+        assertTrue(translator.getObfuscated().empty());
+        assertTrue(translator.getStrikethroughs().empty());
+    }
+
+    @Test
+    public void testSimpleItalicsUnd() {
+        String message = "_i_";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> result = translator.getItalicsUnd();
+        assertEquals(0, result.peek().start);
+        assertEquals(2, result.peek().end);
+        result.pop();
+        assertTrue(result.empty());
+        assertTrue(translator.getItalicsAst().empty());
+        assertTrue(translator.getBold().empty());
+        assertTrue(translator.getUnderlines().empty());
+        assertTrue(translator.getObfuscated().empty());
+        assertTrue(translator.getStrikethroughs().empty());
+    }
+
+    @Test
+    public void testSimpleBold() {
+        String message = "**i**";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> result = translator.getBold();
+        assertEquals(0, result.peek().start);
+        assertEquals(3, result.peek().end);
+        result.pop();
+        assertTrue(result.empty());
+        assertTrue(translator.getItalicsAst().empty());
+        assertTrue(translator.getItalicsUnd().empty());
+        assertTrue(translator.getUnderlines().empty());
+        assertTrue(translator.getObfuscated().empty());
+        assertTrue(translator.getStrikethroughs().empty());
+    }
+
+    @Test
+    public void testSimpleUnderline() {
+        String message = "__i__";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> result = translator.getUnderlines();
+        assertEquals(0, result.peek().start);
+        assertEquals(3, result.peek().end);
+        result.pop();
+        assertTrue(result.empty());
+        assertTrue(translator.getItalicsAst().empty());
+        assertTrue(translator.getBold().empty());
+        assertTrue(translator.getItalicsUnd().empty());
+        assertTrue(translator.getObfuscated().empty());
+        assertTrue(translator.getStrikethroughs().empty());
+    }
+
+    @Test
+    public void testSimpleObfuscated() {
+        String message = "||i||";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> result = translator.getObfuscated();
+        assertEquals(0, result.peek().start);
+        assertEquals(3, result.peek().end);
+        result.pop();
+        assertTrue(result.empty());
+        assertTrue(translator.getItalicsAst().empty());
+        assertTrue(translator.getBold().empty());
+        assertTrue(translator.getItalicsUnd().empty());
+        assertTrue(translator.getUnderlines().empty());
+        assertTrue(translator.getStrikethroughs().empty());
+    }
+
+    @Test
+    public void testSimpleStrikethrough() {
+        String message = "~~i~~";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> result = translator.getStrikethroughs();
+        assertEquals(0, result.peek().start);
+        assertEquals(3, result.peek().end);
+        result.pop();
+        assertTrue(result.empty());
+        assertTrue(translator.getItalicsAst().empty());
+        assertTrue(translator.getBold().empty());
+        assertTrue(translator.getItalicsUnd().empty());
+        assertTrue(translator.getUnderlines().empty());
+        assertTrue(translator.getObfuscated().empty());
+    }
+
+    @Test
+    public void testSimpleBoldItalics() {
+        String message = "***i***";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> bolds = translator.getBold();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italics = translator.getItalicsAst();
+
+        assertEquals(0, bolds.peek().start);
+        assertEquals(5, bolds.peek().end);
+        bolds.pop();
+        assertTrue(bolds.empty());
+
+        assertEquals(2, italics.peek().start);
+        assertEquals(4, italics.peek().end);
+        italics.pop();
+        assertTrue(italics.empty());
+    }
+
+    @Test
+    public void testSimpleUnderlineItalics() {
+        String message = "___i___";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> unds = translator.getUnderlines();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italics = translator.getItalicsUnd();
+
+        assertEquals(0, unds.peek().start);
+        assertEquals(5, unds.peek().end);
+        unds.pop();
+        assertTrue(unds.empty());
+
+        assertEquals(2, italics.peek().start);
+        assertEquals(4, italics.peek().end);
+        italics.pop();
+        assertTrue(italics.empty());
+    }
+
+    @Test
+    public void testSimpleDisjoints() {
+        String message = "___i___*j*";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> unds = translator.getUnderlines();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italicsUnd = translator.getItalicsUnd();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italicsAst = translator.getItalicsAst();
+
+        assertEquals(0, unds.peek().start);
+        assertEquals(5, unds.peek().end);
+        unds.pop();
+        assertTrue(unds.empty());
+
+        assertEquals(2, italicsUnd.peek().start);
+        assertEquals(4, italicsUnd.peek().end);
+        italicsUnd.pop();
+        assertTrue(italicsUnd.empty());
+
+        assertEquals(7, italicsAst.peek().start);
+        assertEquals(9, italicsAst.peek().end);
+        italicsAst.pop();
+        assertTrue(italicsAst.empty());
+    }
+
+    // @Test
+    // public void testOverlappingItalicsBold1() {
+    //     String message = "***b**i*";
+    //     DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+    //     Stack<DiscordToMinecraftFormattingTranslator.Range> bold = translator.getBold();
+    //     Stack<DiscordToMinecraftFormattingTranslator.Range> italicsAst = translator.getItalicsAst();
+
+    //     assertEquals(1, bold.peek().start);
+    //     assertEquals(4, bold.peek().end);
+    //     bold.pop();
+    //     assertTrue(bold.empty());
+
+    //     assertEquals(0, italicsAst.peek().start);
+    //     assertEquals(7, italicsAst.peek().end);
+    //     italicsAst.pop();
+    //     assertTrue(italicsAst.empty());
+    // }
+
+    @Test
+    public void testOverlappingItalicsBold2() {
+        String message = "***i*b**";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> bold = translator.getBold();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italicsAst = translator.getItalicsAst();
+
+        assertEquals(0, bold.peek().start);
+        assertEquals(6, bold.peek().end);
+        bold.pop();
+        assertTrue(bold.empty());
+
+        assertEquals(2, italicsAst.peek().start);
+        assertEquals(4, italicsAst.peek().end);
+        italicsAst.pop();
+        assertTrue(italicsAst.empty());
+    }
+}

--- a/src/test/java/TestDiscordToMinecraftFormattingTranslator.java
+++ b/src/test/java/TestDiscordToMinecraftFormattingTranslator.java
@@ -168,7 +168,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
     }
 
     // @Test
-    // public void testOverlappingItalicsBold1() {
+    // public void testOverlappingItalicsBold0() {
     //     String message = "***b**i*";
     //     DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
     //     Stack<DiscordToMinecraftFormattingTranslator.Range> bold = translator.getBold();
@@ -186,6 +186,24 @@ public class TestDiscordToMinecraftFormattingTranslator {
     // }
 
     @Test
+    public void testOverlappingItalicsBold1() {
+        String message = "_**b**i_";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> bold = translator.getBold();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italicsUnd = translator.getItalicsUnd();
+
+        assertEquals(1, bold.peek().start);
+        assertEquals(4, bold.peek().end);
+        bold.pop();
+        assertTrue(bold.empty());
+
+        assertEquals(0, italicsUnd.peek().start);
+        assertEquals(7, italicsUnd.peek().end);
+        italicsUnd.pop();
+        assertTrue(italicsUnd.empty());
+    }
+
+    @Test
     public void testOverlappingItalicsBold2() {
         String message = "***i*b**";
         DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
@@ -201,5 +219,76 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(4, italicsAst.peek().end);
         italicsAst.pop();
         assertTrue(italicsAst.empty());
+    }
+
+    @Test
+    public void testOverlappingUnderlinedItalics1() {
+        String message = "___i_u__";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> unds = translator.getUnderlines();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italicsUnd = translator.getItalicsUnd();
+
+        assertEquals(0, unds.peek().start);
+        assertEquals(6, unds.peek().end);
+        unds.pop();
+        assertTrue(unds.empty());
+
+        assertEquals(2, italicsUnd.peek().start);
+        assertEquals(4, italicsUnd.peek().end);
+        italicsUnd.pop();
+        assertTrue(italicsUnd.empty());
+    }
+
+    @Test
+    public void testComplexOverlap() {
+        String message = "a~~b*cd__e__f*g~~**b**";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> unds = translator.getUnderlines();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italics = translator.getItalicsAst();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> strikes = translator.getStrikethroughs();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> bold = translator.getBold();
+
+        assertEquals(7, unds.peek().start);
+        assertEquals(10, unds.peek().end);
+        unds.pop();
+        assertTrue(unds.empty());
+
+        assertEquals(4, italics.peek().start);
+        assertEquals(13, italics.peek().end);
+        italics.pop();
+        assertTrue(italics.empty());
+
+        assertEquals(1, strikes.peek().start);
+        assertEquals(15, strikes.peek().end);
+        strikes.pop();
+        assertTrue(strikes.empty());
+
+        assertEquals(17, bold.peek().start);
+        assertEquals(20, bold.peek().end);
+        bold.pop();
+        assertTrue(bold.empty());
+    }
+
+    @Test
+    public void testMultipleItalics() {
+        String message = "*a*bbbb*ccc*d*ee*f*g*h*i*";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italics = translator.getItalicsAst();
+
+        assertEquals(0, italics.peek().start);
+        assertEquals(2, italics.peek().end);
+        italics.pop();
+        assertEquals(7, italics.peek().start);
+        assertEquals(11, italics.peek().end);
+        italics.pop();
+        assertEquals(13, italics.peek().start);
+        assertEquals(16, italics.peek().end);
+        italics.pop();
+        assertEquals(18, italics.peek().start);
+        assertEquals(20, italics.peek().end);
+        italics.pop();
+        assertEquals(22, italics.peek().start);
+        assertEquals(24, italics.peek().end);
+        italics.pop();
     }
 }

--- a/src/test/java/TestDiscordToMinecraftFormattingTranslator.java
+++ b/src/test/java/TestDiscordToMinecraftFormattingTranslator.java
@@ -25,6 +25,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertTrue(translator.getUnderlines().empty());
         assertTrue(translator.getObfuscated().empty());
         assertTrue(translator.getStrikethroughs().empty());
+        translator.translate();
     }
 
     @Test
@@ -41,6 +42,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertTrue(translator.getUnderlines().empty());
         assertTrue(translator.getObfuscated().empty());
         assertTrue(translator.getStrikethroughs().empty());
+        translator.translate();
     }
 
     @Test
@@ -57,6 +59,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertTrue(translator.getUnderlines().empty());
         assertTrue(translator.getObfuscated().empty());
         assertTrue(translator.getStrikethroughs().empty());
+        translator.translate();
     }
 
     @Test
@@ -73,6 +76,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertTrue(translator.getItalicsUnd().empty());
         assertTrue(translator.getObfuscated().empty());
         assertTrue(translator.getStrikethroughs().empty());
+        translator.translate();
     }
 
     @Test
@@ -89,6 +93,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertTrue(translator.getItalicsUnd().empty());
         assertTrue(translator.getUnderlines().empty());
         assertTrue(translator.getStrikethroughs().empty());
+        translator.translate();
     }
 
     @Test
@@ -105,6 +110,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertTrue(translator.getItalicsUnd().empty());
         assertTrue(translator.getUnderlines().empty());
         assertTrue(translator.getObfuscated().empty());
+        translator.translate();
     }
 
     @Test
@@ -123,6 +129,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(4, italics.peek().end);
         italics.pop();
         assertTrue(italics.empty());
+        translator.translate();
     }
 
     @Test
@@ -141,6 +148,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(4, italics.peek().end);
         italics.pop();
         assertTrue(italics.empty());
+        translator.translate();
     }
 
     @Test
@@ -165,6 +173,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(9, italicsAst.peek().end);
         italicsAst.pop();
         assertTrue(italicsAst.empty());
+        translator.translate();
     }
 
     // @Test
@@ -201,6 +210,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(7, italicsUnd.peek().end);
         italicsUnd.pop();
         assertTrue(italicsUnd.empty());
+        translator.translate();
     }
 
     @Test
@@ -219,6 +229,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(4, italicsAst.peek().end);
         italicsAst.pop();
         assertTrue(italicsAst.empty());
+        translator.translate();
     }
 
     @Test
@@ -237,6 +248,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(4, italicsUnd.peek().end);
         italicsUnd.pop();
         assertTrue(italicsUnd.empty());
+        translator.translate();
     }
 
     @Test
@@ -267,6 +279,7 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(20, bold.peek().end);
         bold.pop();
         assertTrue(bold.empty());
+        translator.translate();
     }
 
     @Test
@@ -290,5 +303,75 @@ public class TestDiscordToMinecraftFormattingTranslator {
         assertEquals(22, italics.peek().start);
         assertEquals(24, italics.peek().end);
         italics.pop();
+        translator.translate();
+    }
+    @Test
+    public void testMultipleItalicsTranslateFirst() {
+        String message = "*a*bbbb*ccc*d*ee*f*_g_*h_i_";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        translator.translate();
+    }
+
+    @Test
+    public void testEscapeBasic() {
+        String message = "\\*a\\*b*c*";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italics = translator.getItalicsAst();
+
+        assertEquals(6, italics.peek().start);
+        assertEquals(8, italics.peek().end);
+        italics.pop();
+        assertTrue(italics.empty());
+        translator.translate();
+    }
+
+    @Test
+    public void testEscapeBasic2() {
+        String message = "\\**a**";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> bold = translator.getBold();
+
+        assertTrue(bold.empty());
+        translator.translate();
+    }
+
+    @Test
+    public void testEscapedEscape() {
+        String message = "*\\\\a*";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italics = translator.getItalicsAst();
+
+        assertEquals(0, italics.peek().start);
+        assertEquals(4, italics.peek().end);
+        italics.pop();
+        assertTrue(italics.empty());
+        translator.translate();
+    }
+
+    @Test
+    public void testUnclosedFormatTopStack() {
+        String message = "b*_c*";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italicsAst = translator.getItalicsAst();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> italicsUnd = translator.getItalicsUnd();
+
+        assertEquals(1, italicsAst.peek().start);
+        assertEquals(4, italicsAst.peek().end);
+        italicsAst.pop();
+        assertTrue(italicsAst.empty());
+        assertTrue(italicsUnd.empty());
+        translator.translate();
+    }
+
+    @Test
+    public void testFakeStrikeObfuscated() {
+        String message = "~b~|c|";
+        DiscordToMinecraftFormattingTranslator translator = new DiscordToMinecraftFormattingTranslator(message);
+        Stack<DiscordToMinecraftFormattingTranslator.Range> strikes = translator.getStrikethroughs();
+        Stack<DiscordToMinecraftFormattingTranslator.Range> obs = translator.getObfuscated();
+
+        assertTrue(strikes.empty());
+        assertTrue(obs.empty());
+        translator.translate();
     }
 }


### PR DESCRIPTION
Again, this isn't really something that can be tested apart from manual end-to-end tests, so I'll drop the screenshots of the tests I ran locally to demonstrate this enhancement:

Test 1 (green):
![1](https://user-images.githubusercontent.com/43277421/144966168-7a94286d-19e6-48d8-849c-e022ceb6ff3c.png)
![2](https://user-images.githubusercontent.com/43277421/144966186-00576397-f499-4a09-9e59-7c212cbc21c0.png)

Test 2 (pink):
![3](https://user-images.githubusercontent.com/43277421/144966203-6c75168a-542d-46dd-bfed-43d1095b8464.png)
![4](https://user-images.githubusercontent.com/43277421/144966212-854988e4-9029-4805-9c62-00a1f484ee49.png)

Test 3 (gray):
![5](https://user-images.githubusercontent.com/43277421/144966219-3705b78e-0451-4273-9325-a8cd4fb7e079.png)
![6](https://user-images.githubusercontent.com/43277421/144966223-2001d897-6fe5-4919-9f51-2a172c2e0774.png)

Nothing too fancy here, just replaced the old hex formatting string with a java Color object.
 